### PR TITLE
epoch 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Ignore Python virtual environments
+.env/
+casting_defect_detection/
+
+# Ignore Python cache files
+__pycache__/
+*.py[cod]
+*.so
+*.pyd
+
+# Ignore model artifacts and experiment tracking
+mlartifacts/
+mlruns/
+temp_best_model/
+best_model_info.txt
+
+# Ignore data and temporary files
+data/
+*.log
+*.tmp
+
+# Ignore system and editor files
+.DS_Store
+*.swp
+*.swo
+
+
+
+# If using secrets or API keys in .env
+.env

--- a/train/train.py
+++ b/train/train.py
@@ -14,7 +14,7 @@ mlflow.set_experiment("Defect_Detection_CNN_Training")
 
 IMAGE_SIZE = (128, 128)
 BATCH_SIZE = 32
-EPOCHS = 2 # Reduced for faster execution in CI/CD, can be increased
+EPOCHS = 6 # Reduced for faster execution in CI/CD, can be increased
 
 def create_cnn_model(input_shape, num_filters, kernel_size, activation='relu'):
     model = tf.keras.Sequential([


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased the number of training epochs for the CNN model from 2 to 6.
  * Added a `.gitignore` file to exclude unnecessary files and directories from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->